### PR TITLE
Prepend project name to environment name when naming servers

### DIFF
--- a/web.tf
+++ b/web.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "web" {
   monitoring             = true
 
   tags = {
-    Name = "${var.project_environment}-web${count.index+1}"
+    Name = "${var.project_name}-${var.project_environment}-web${count.index+1}"
   }
 
   root_block_device {
@@ -24,7 +24,7 @@ resource aws_eip "web" {
   instance = aws_instance.web[count.index].id
 
   tags = {
-    Name = "${var.project_environment}-web${count.index+1}"
+    Name = "${var.project_name}-${var.project_environment}-web${count.index+1}"
   }
 }
 

--- a/worker.tf
+++ b/worker.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "worker" {
   }
 
   tags = {
-    Name = "${var.project_environment}-worker${count.index+1}"
+    Name = "${var.project_name}-${var.project_environment}-worker${count.index+1}"
   }
 }
 
@@ -24,7 +24,7 @@ resource aws_eip "worker" {
   instance = aws_instance.worker[count.index].id
 
   tags = {
-    Name = "${var.project_environment}-worker${count.index+1}"
+    Name = "${var.project_name}-${var.project_environment}-worker${count.index+1}"
   }
 }
 


### PR DESCRIPTION
Doing this so that all projects don't have hostnames of production-web1, production-web2, etc.

There were other places where we could prepend the project name, but they're internal to aws and so didn't seem that important to change. I guess the same could be said for the elastic IPs but they were in the same file and I just did it 🤷