### PR TITLE
Update tls security policy to aws recommended version

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -137,7 +137,7 @@ resource "aws_lb_listener" "tls" {
   load_balancer_arn = aws_lb.production.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
   certificate_arn   = local.cert_arn
   default_action {
     type             = "forward"


### PR DESCRIPTION
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies


<img width="330" alt="Screenshot 2023-05-10 at 1 13 42 PM" src="https://github.com/tenforwardconsulting/terraform-subspace-oxenwagen/assets/651234/3e84f6bc-e1ac-4188-8abd-5a60cd10b85a">
