### PR TITLE
Add project name to db subnet group name

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -15,4 +15,5 @@ resource "aws_db_instance" "production" {
   vpc_security_group_ids   = [aws_security_group.production-rds.id]
   storage_encrypted        = true
   final_snapshot_identifier = var.final_snapshot_identifier
+  snapshot_identifier      = var.snapshot_identifier
 }

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -59,10 +59,11 @@ resource "aws_lb_listener" "http" {
   default_action {
     type             = "redirect"
     redirect {
-      path        = "/#{host}:443/#{path}?#{query}"
+      path        = "/#{host}:443/#{path}"
       port        = "443"
       protocol    = "HTTPS"
       status_code = "HTTP_301"
+      query       = "#{query}"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,10 @@ variable database_allocated_storage { type = number }
 variable database_max_allocated_storage { type = number }
 variable database_iops { type = number }
 variable final_snapshot_identifier { type = string }
-variable snapshot_identifier { type = string }
+variable snapshot_identifier { 
+  type = string
+  default = null
+}
 
 # role.tf
 variable delegated_access_account_id {

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,7 @@ variable database_allocated_storage { type = number }
 variable database_max_allocated_storage { type = number }
 variable database_iops { type = number }
 variable final_snapshot_identifier { type = string }
+variable snapshot_identifier { type = string }
 
 # role.tf
 variable delegated_access_account_id {

--- a/vpc.tf
+++ b/vpc.tf
@@ -25,11 +25,11 @@ resource "aws_subnet" "production-internal-c" {
 }
 
 resource "aws_db_subnet_group" "production-subnet-group" {
-  name       = "production-subnet-group"
+  name       = "production-${var.project_name}"
   subnet_ids = [aws_subnet.production-internal-a.id, aws_subnet.production-internal-b.id, aws_subnet.production-internal-c.id]
 
   tags = {
-    Name = "production-subnet-group"
+    Name = "production-${var.project_name}"
   }
 }
 


### PR DESCRIPTION
To avoid naming conflicts when there are multiple projects in a client's AWS org