### PR TITLE
WIP Upgrade aws provider to 5.x. Create SNS Topic, SNS Sub, and Cloudwatch alarm for worker instance StatusCheckFailed

### DIFF
--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -76,7 +76,7 @@ resource "aws_lb_target_group" "production" {
   vpc_id   = aws_vpc.production-internal.id
   health_check {
     enabled             = true
-    matcher             = "200,301"
+    matcher             = "200"
     port                = "80"
     protocol            = "HTTP"
     path                = var.lb_health_check_path

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67.0"
+      version = "~> 5.31.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 4.67.0"
     }
   }
 }

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,9 @@
+resource "aws_sns_topic" "ec2-alarm" {
+  name   = "${var.project_name}-${var.project_environment}-ec2-alarm"
+}
+
+resource "aws_sns_topic_subscription" "ec2-alarm_email_target" {
+  topic_arn = aws_sns_topic.ec2-alarm.arn
+  protocol  = "email"
+  endpoint  = "alerts@tenforwardconsulting.com"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,12 +1,5 @@
 resource "aws_vpc" "production-internal" {
   cidr_block = "172.31.0.0/16"
-
-  tags = {
-    Name = "${var.project_environment}-${var.project_name}"
-  }
-  tags_all = {
-    Name = "${var.project_environment}-${var.project_name}"
-  }
 }
 
 resource "aws_internet_gateway" "gw" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,12 @@
 resource "aws_vpc" "production-internal" {
   cidr_block = "172.31.0.0/16"
+
+  tags = {
+    Name = "${var.project_environment}-${var.project_name}"
+  }
+  tags_all = {
+    Name = "${var.project_environment}-${var.project_name}"
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
@@ -94,6 +101,12 @@ resource "aws_security_group" "production-internal" {
   name        = "${var.project_environment}-internal"
   description = "${var.project_environment}-internal"
   vpc_id      = aws_vpc.production-internal.id
+  tags = {
+    Name = "${var.project_environment}-${var.project_name}"
+  }
+  tags_all = {
+    Name = "${var.project_environment}-${var.project_name}"
+  }
 
   ingress {
     description      = "All traffic from webservers and workers"

--- a/worker.tf
+++ b/worker.tf
@@ -33,3 +33,19 @@ resource "aws_eip_association" "worker_eip_assoc" {
   instance_id   = aws_instance.worker[count.index].id
   allocation_id = aws_eip.worker[count.index].id
 }
+
+resource "aws_cloudwatch_metric_alarm" "worker" {
+  count                     = var.worker_instance_count
+  alarm_name                = "${var.project_name}-${var.project_environment}-worker-status-${aws_instance.worker[count.index].id}"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = 2
+  metric_name               = "StatusCheckFailed"
+  namespace                 = "AWS/EC2"
+  period                    = 300
+  statistic                 = "Average"
+  alarm_description         = "This metric monitors both EC2 instance and system status"
+  insufficient_data_actions = []
+  dimensions = {
+    InstanceId = "${aws_instance.worker[count.index].id}"
+  }
+}

--- a/worker.tf
+++ b/worker.tf
@@ -48,4 +48,6 @@ resource "aws_cloudwatch_metric_alarm" "worker" {
   dimensions = {
     InstanceId = "${aws_instance.worker[count.index].id}"
   }
+  actions_enabled     = "true"
+  alarm_actions       = [aws_sns_topic.ec2-alarm.arn]
 }


### PR DESCRIPTION
Setting up a cloudwatch alarm for ec2 instance statuscheckfailed, currently just on the worker but we might as well do it on web instances too

TODO:

- [ ] Add to web.tf ??
- [ ] Add alert action to reboot (do we want that everywhere?)