### PR TITLE
Replace Redis OSS with Valkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ If you do not specify either `lb_domain_name` or `lb_certificate_arn` your load 
 Most rails projects need a redis for things like sidekiq, actioncable, etc, so this tf script can create an elasticache redis instance/cluster for you.  Alternatively, you can configure a worker server to run redis, but using elasticache is is usually preferred.
 
     # Number of redis nodes in the cluster.
-    redis_node_count = 1
+    redis_cluster_count = 1
     redis_node_type = "cache.t4g.micro"
-    redis_engine_version = "6.x"
-    redis_parameter_group_name = "default.redis6.x"
+    redis_engine_version = "8.2"
+    redis_parameter_group_name = "default.valkey8"
+    redis_apply_immediately = true
 
 By default, this will *not* create a redis cluster.

--- a/redis.tf
+++ b/redis.tf
@@ -1,6 +1,6 @@
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = "production"
-  description                   = "Production Valkey cluster"
+  replication_group_id          = "${var.project_environment}"
+  description                   = "${var.project_environment} valkey cluster"
   count                         = var.redis_cluster_count > 0 ? 1 : 0
   engine                        = "valkey"
   apply_immediately             = var.redis_apply_immediately
@@ -16,7 +16,7 @@ resource "aws_elasticache_replication_group" "redis" {
 
 resource "aws_elasticache_subnet_group" "redis_subnet" {
   count      = var.redis_cluster_count > 0 ? 1 : 0
-  name       = "production-cache-subnet"
+  name       = "${var.project_environment}-cache-subnet"
   subnet_ids = data.aws_subnets.subnets.ids
 }
 

--- a/redis.tf
+++ b/redis.tf
@@ -1,26 +1,27 @@
-resource "aws_elasticache_cluster" "redis" {
-  count                = var.redis_node_count > 0 ? 1 : 0
-  cluster_id           = "${var.project_environment}"
-  engine               = "redis"
-  apply_immediately    = var.redis_apply_immediately
-  subnet_group_name    = aws_elasticache_subnet_group.redis_subnet[0].name
-  node_type            = var.redis_node_type
-  num_cache_nodes      = var.redis_node_count
-  engine_version       = var.redis_engine_version
-  parameter_group_name = var.redis_parameter_group_name
-
-  port                 = 6379
-  security_group_ids   = [aws_security_group.production-redis[0].id]
+resource "aws_elasticache_replication_group" "redis" {
+  replication_group_id          = "production"
+  description                   = "Production Valkey cluster"
+  count                         = var.redis_cluster_count > 0 ? 1 : 0
+  engine                        = "valkey"
+  apply_immediately             = var.redis_apply_immediately
+  subnet_group_name             = aws_elasticache_subnet_group.redis_subnet[0].name
+  node_type                     = var.redis_node_type
+  num_cache_clusters            = var.redis_cluster_count
+  engine_version                = var.redis_engine_version
+  parameter_group_name          = var.redis_parameter_group_name
+  automatic_failover_enabled    = false
+  port                          = 6379
+  security_group_ids            = [aws_security_group.production-redis[0].id]
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet" {
-  count      = var.redis_node_count > 0 ? 1 : 0
-  name       = "${var.project_environment}-cache-subnet"
+  count      = var.redis_cluster_count > 0 ? 1 : 0
+  name       = "production-cache-subnet"
   subnet_ids = data.aws_subnets.subnets.ids
 }
 
 resource "aws_security_group" "production-redis" {
-  count       = var.redis_node_count > 0 ? 1 : 0
+  count       = var.redis_cluster_count > 0 ? 1 : 0
   name        = "${var.project_environment}-redis"
   description = "${var.project_environment}-redis"
   vpc_id      = aws_vpc.production-internal.id

--- a/redis.tf
+++ b/redis.tf
@@ -1,7 +1,7 @@
 resource "aws_elasticache_replication_group" "redis" {
   replication_group_id          = "${var.project_environment}"
   description                   = "${var.project_environment} valkey cluster"
-  count                         = var.redis_cluster_count > 0 ? 1 : 0
+  count                         = var.redis_cluster_count
   engine                        = "valkey"
   apply_immediately             = var.redis_apply_immediately
   subnet_group_name             = aws_elasticache_subnet_group.redis_subnet[0].name

--- a/variables.tf
+++ b/variables.tf
@@ -54,7 +54,7 @@ variable database_allocated_storage { type = number }
 variable database_max_allocated_storage { type = number }
 variable database_iops { type = number }
 variable final_snapshot_identifier { type = string }
-variable snapshot_identifier { 
+variable snapshot_identifier {
   type = string
   default = null
 }
@@ -66,7 +66,7 @@ variable delegated_access_account_id {
 }
 
 # redis.tf
-variable redis_node_count {
+variable redis_cluster_count {
   type = number
   default = 0
 }


### PR DESCRIPTION
Making this change because Redis decided to not be open source, and there is more explanation here: https://aws.amazon.com/elasticache/what-is-valkey/

Also, Valkey has lower AWS costs